### PR TITLE
Host pimusicbox.com on GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.pimusicbox.com

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Pi MusicBox web site
 ====================
 
-This is the source for the http://pimusicbox.github.io/ web site, hosted at
+This is the source for the http://www.pimusicbox.com/ web site, hosted at
 GitHub Pages.
 
 To deploy changes to the site, simply push to the

--- a/index.html
+++ b/index.html
@@ -133,12 +133,7 @@
         <h2>Download</h2>
         <p>Here you can find an image for the SD Card for you Pi. It's around 290MB in (compressed) size; 950MB uncompressed (<a href="https://github.com/woutervanwijk/Pi-MusicBox/blob/master/changes.rst">changes</a>):<br/><br/>
             <ul>
-
-
-                <li><a href="http://dl.mopidy.com/musicbox0.6.zip">Download Pi MusicBox 0.6 via </a> <a href="http://www.rackspace.com">RackSpace</a> </li>
-                <li><a href="musicbox0.6.zip">Download directly from this site (slower)</a></li><br/>
-
-
+                <li><a href="http://dl.mopidy.com/musicbox0.6.zip">Download Pi MusicBox 0.6</a> via <a href="http://www.rackspace.com">RackSpace</a> </li>
             </ul>
   <!--   <a href="prerelease.html">Head overhere to download the latest prerelease-version, including support for the Pi 2!</a><br/><br/> 
 -->


### PR DESCRIPTION
Given:
- [x] first, the merge of this pull request, and then
- [ ] second, the following DNS setup:
  - pimusicbox.com A 192.30.252.153
  - pimusicbox.com A 192.30.252.154
  - www.pimusicbox.com CNAME pimusicbox.github.io

Then we'll see this behavior:
- http://pimusicbox.com/ will redirect to http://www.pimusicbox.com/
- http://www.pimusicbox.com/ will be served from GitHub Pages

I hope this is an interesting setup, making the contribution workflow for the Pi MusicBox web site easier.

Assigning to @woutervanwijk as he's the only one with access to the pimusicbox.com domain's DNS.
